### PR TITLE
Fix tests and use default values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ version = "0.1.3"
 readme = "README.md"
 categories = ["multimedia::audio"]
 
+[dev-dependencies]
+all_asserts = "0.1.4"
+
 [build-dependencies]
 bindgen = "0.49"
 pathdiff = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ readme = "README.md"
 categories = ["multimedia::audio"]
 
 [build-dependencies]
-bindgen = "0.43"
+bindgen = "0.49"
 pathdiff = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -51,6 +51,7 @@ fn main() {
     };
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
+	.derive_default(true)
         .generate()
         .expect("Unable to generate bindings");
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod tests {
                 end_of_input: 0,
                 input_frames_used: 0,
                 output_frames_gen: 0,
+                ..Default::default()
             };
             src_simple(&mut src_pass_1 as *mut SRC_DATA, SRC_SINC_BEST_QUALITY as i32, 1);
             // Convert from 48000Hz to 44100Hz.
@@ -39,6 +40,7 @@ mod tests {
                 end_of_input: 0,
                 input_frames_used: 0,
                 output_frames_gen: 0,
+                ..Default::default()
             };
             src_simple(&mut src_pass_2 as *mut SRC_DATA, SRC_SINC_BEST_QUALITY as i32, 1);
             // Expect the difference between all input frames and all output frames to be less than
@@ -70,6 +72,7 @@ mod tests {
                 end_of_input: 0,
                 input_frames_used: 0,
                 output_frames_gen: 0,
+                ..Default::default()
             };
             // Convert the input data in slices.
             let slices = 10;
@@ -90,6 +93,7 @@ mod tests {
                 end_of_input: 0,
                 input_frames_used: 0,
                 output_frames_gen: 0,
+                ..Default::default()
             };
             src_simple(&mut src_reverse as *mut SRC_DATA, SRC_SINC_BEST_QUALITY as i32, 1);
             // Expect the difference between all input frames and all output frames to be less than

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,101 +5,133 @@
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[cfg(test)]
+#[macro_use]
+extern crate all_asserts;
+
+#[cfg(test)]
 mod tests {
     use super::*;
-    use std::mem;
 
     #[test]
     fn simple_sample_rate_conversion() {
         unsafe {
+            let from = 44100;
+            let to = 48000;
+            let ratio = to as f64 / from as f64;
+
             // Setup sample data and storage.
-            let freq = ::std::f32::consts::PI * 880f32 / 44100f32;
-            let mut input: Vec<f32> = (0..44100).map(|i| (freq * i as f32).sin()).collect();
-            let mut resampled = vec![0f32;48000];
-            let mut output = vec![0f32;44100];
+            let freq = ::std::f32::consts::PI * 880f32 / from as f32;
+            let mut input: Vec<f32> = (0..from).map(|i| (freq * i as f32).sin()).collect();
+            let mut resampled = vec![0f32; to];
+            let mut output = vec![0f32; from];
+
             // Convert from 44100Hz to 48000Hz.
             let mut src_pass_1 = SRC_DATA {
                 data_in: input.as_mut_ptr(),
                 data_out: resampled.as_mut_ptr(),
-                input_frames: 44100,
-                output_frames: 48000,
-                src_ratio: 48000f64 / 44100f64,
-                end_of_input: 0,
-                input_frames_used: 0,
-                output_frames_gen: 0,
+                input_frames: (input.len() as i32).into(),
+                output_frames: (resampled.len() as i32).into(),
+                src_ratio: ratio,
                 ..Default::default()
             };
-            src_simple(&mut src_pass_1 as *mut SRC_DATA, SRC_SINC_BEST_QUALITY as i32, 1);
+            let err = src_simple(&mut src_pass_1 as *mut SRC_DATA, SRC_SINC_BEST_QUALITY as i32, 1);
+            assert_eq!(err, 0);
+            assert_eq!(src_pass_1.output_frames_gen, src_pass_1.output_frames);
+            assert_eq!(src_pass_1.input_frames_used, src_pass_1.input_frames);
+
             // Convert from 48000Hz to 44100Hz.
             let mut src_pass_2 = SRC_DATA {
                 data_in: resampled.as_mut_ptr(),
                 data_out: output.as_mut_ptr(),
-                input_frames: 48000,
-                output_frames: 44100,
-                src_ratio: 44100f64 / 48000f64,
-                end_of_input: 0,
-                input_frames_used: 0,
-                output_frames_gen: 0,
+                input_frames: (resampled.len() as i32).into(),
+                output_frames: (output.len() as i32).into(),
+                src_ratio: 1f64/ratio,
                 ..Default::default()
             };
-            src_simple(&mut src_pass_2 as *mut SRC_DATA, SRC_SINC_BEST_QUALITY as i32, 1);
+            let err = src_simple(&mut src_pass_2 as *mut SRC_DATA, SRC_SINC_BEST_QUALITY as i32, 1);
+            assert_eq!(err, 0);
+            assert_eq!(src_pass_2.output_frames_gen, src_pass_2.output_frames);
+            assert_eq!(src_pass_2.input_frames_used, src_pass_2.input_frames);
+
             // Expect the difference between all input frames and all output frames to be less than
             // an epsilon.
             let error = input.iter().zip(output).fold(0f32, |max, (input, output)| max.max((input - output).abs()));
-            assert!(error < 2f32);
+            assert_lt!(error, 0.002);
         }
     }
 
     #[test]
     fn complex_sample_rate_conversion() {
         unsafe {
+            let from = 44100;
+            let to = 44100;
+            let ratio = to as f64 / from as f64;
+
             // Setup sample data and storage.
-            let freq = ::std::f32::consts::PI * 880f32 / 44100f32;
-            let mut input: Vec<f32> = (0..44100).map(|i| (freq * i as f32).sin()).collect();
-            let mut resampled = vec![0f32;48000];
-            let mut output = vec![0f32;44100];
+            let freq = ::std::f32::consts::PI * 880f32 / from as f32;
+            let mut input: Vec<f32> = (0..from).map(|i| (freq * i as f32).sin()).collect();
+            let mut resampled = vec![0f32; to];
+            let mut output = vec![0f32; from];
+
             // Create the samplerate converter.
             let mut error = 0i32;
             let converter: *mut SRC_STATE = src_new(SRC_SINC_BEST_QUALITY as i32, 1, &mut error as *mut i32);
-            assert!(error == 0);
+
+            assert_eq!(error, 0);
+
             // Initial input configuration.
+            let slices: usize = 10;
+
             let mut src = SRC_DATA {
-                data_in: input.as_mut_ptr(),
-                data_out: resampled.as_mut_ptr(),
-                input_frames: 44100,
-                output_frames: 48000,
-                src_ratio: 48000f64 / 44100f64,
-                end_of_input: 0,
-                input_frames_used: 0,
-                output_frames_gen: 0,
+                src_ratio: ratio,
+                input_frames: (input.len() as i32 / slices as i32).into(),
+                output_frames: (resampled.len() as i32 / slices as i32).into(),
                 ..Default::default()
             };
+
             // Convert the input data in slices.
-            let slices = 10;
-            for i in 0..slices {
-                src.data_in = input[i * 44100 / slices..(i + 1) * 44100 / slices].as_mut_ptr();
-                src.data_out = resampled[i * 48000 / slices..(i + 1) * 48000 / slices].as_mut_ptr();
-                src_process(converter, &mut src as *mut SRC_DATA);
+            let mut out_pos = 0;
+            for i in 0..slices+1 {
+                if i == (slices - 1) {
+                    src.end_of_input = 1;
+                }
+                if i == slices {
+                    src.input_frames = 0;
+                } else {
+                    src.data_in = input[i * from / slices..].as_mut_ptr();
+                }
+
+                src.data_out = resampled[out_pos..].as_mut_ptr();
+
+                let err = src_process(converter, &mut src as *mut SRC_DATA);
+                assert_eq!(err, 0);
+                assert_eq!(src.input_frames_used, src.input_frames);
+                out_pos += src.output_frames_gen as usize;
             }
+            assert_eq!(out_pos, resampled.len());
+
             // Delete the converter.
             src_delete(converter);
+
             // Convert back from 48000Hz to 44100Hz.
             let mut src_reverse = SRC_DATA {
                 data_in: resampled.as_mut_ptr(),
                 data_out: output.as_mut_ptr(),
-                input_frames: 48000,
-                output_frames: 44100,
-                src_ratio: 44100f64 / 48000f64,
-                end_of_input: 0,
-                input_frames_used: 0,
-                output_frames_gen: 0,
+                input_frames: (resampled.len() as i32).into(),
+                output_frames: (output.len() as i32).into(),
+                src_ratio: 1f64/ratio,
                 ..Default::default()
             };
-            src_simple(&mut src_reverse as *mut SRC_DATA, SRC_SINC_BEST_QUALITY as i32, 1);
+            let err = src_simple(&mut src_reverse as *mut SRC_DATA, SRC_SINC_BEST_QUALITY as i32, 1);
+
+            assert_eq!(err, 0);
+            assert_eq!(src_reverse.output_frames_gen, src_reverse.output_frames);
+            assert_eq!(src_reverse.input_frames_used, src_reverse.input_frames);
+
             // Expect the difference between all input frames and all output frames to be less than
             // an epsilon.
             let error = input.iter().zip(output).fold(0f32, |max, (input, output)| max.max((input - output).abs()));
-            assert!(error < 2f32);
+            assert_lt!(error, 0.002);
         }
     }
 }


### PR DESCRIPTION
This PR does 3 things:
  1.  Bumps dependecies
  2.  Sets `derive_default` which allows to use `Default::default()` in struct initialization. This makes it easy to use them on different architectures where padding fields can be added by bindgen.
  3. Fixes test which were happily segfaulting. It also makes them work on different platforms thanks to (2) and `into()`, cleans them up and uses `all_asserts` for easier debugging.

Note that in `complex_sample_rate_conversion` `src_process` doesn't always return `ratio*from` samples, it ca actually be less because of the filter delay, because of this `src_process` needs to be called after the processing was finished to get the last few samples out.

I'll soon follow up this PR with a next one to `rust-samplerate` to fix this problem there as well.