### PR TITLE
Use cmake crate for building libsamplerate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,7 +162,7 @@ version = "0.1.7"
 dependencies = [
  "all_asserts 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pathdiff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -178,11 +186,6 @@ dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "peeking_take_while"
@@ -345,6 +348,7 @@ dependencies = [
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum cmake 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
@@ -354,7 +358,6 @@ dependencies = [
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum pathdiff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a3bf70094d203e07844da868b634207e71bfab254fe713171fae9a6e751ccf31"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ all_asserts = "0.1.4"
 
 [build-dependencies]
 bindgen = "0.51"
-pathdiff = "0.1"
+cmake = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -1,67 +1,14 @@
 extern crate bindgen;
-extern crate pathdiff;
+extern crate cmake;
 
-use pathdiff::diff_paths;
 use std::env;
-use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
-
-fn run(cmd: &mut Command) {
-    match cmd.status() {
-        Ok(status) => assert!(status.success()),
-        Err(e) => panic!("Unable to execute {:?}! {}", cmd, e),
-    }
-}
-
-fn build_libsamplerate_unix(src: &PathBuf, dst: &PathBuf) {
-    run(Command::new("cmake")
-        .args(&[
-            "-DCMAKE_C_FLAGS=-fPIC",
-            &format!(
-                "-DCMAKE_BUILD_TYPE={}",
-                if env::var("PROFILE").map(|x| x == "release").unwrap_or(false) {
-                    "Release"
-                } else {
-                    "Debug"
-                }
-            ),
-            diff_paths(&src, &dst).unwrap().to_str().unwrap(),
-        ])
-        .current_dir(&dst));
-    run(Command::new("make").args(&["samplerate"]).current_dir(&dst));
-    let shlib = src.join("src/.libs");
-    let _ = fs::copy(&shlib.join("libsamplerate.a"), &dst.join("libsamplerate.a"));
-    println!("cargo:rustc-flags=-l static=samplerate");
-    println!("cargo:rustc-flags=-L {}", dst.display());
-    println!("cargo:rerun-if-changed={}", src.to_str().unwrap());
-}
-
-fn build_libsamplerate_windows(src: &PathBuf, dst: &PathBuf) {
-    run(Command::new("cmake").args(&[
-        "-DCMAKE_SYSTEM_NAME=Windows",
-        "-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc",
-        "-DCMAKE_C_FLAGS=-fPIC",
-        "-DBUILD_SHARED_LIBS=off",
-        "-DWIN32=on",
-        "-DSNDFILE_INCLUDE_DIR=/usr/include",
-        "-DBUILD_EXAMPLES=OFF",
-        diff_paths(&src, &dst).unwrap().to_str().unwrap(),
-    ]).current_dir(&dst));
-    run(Command::new("make").args(&["samplerate"]).current_dir(&dst));
-    println!("cargo:rustc-flags=-l static=samplerate");
-    println!("cargo:rustc-flags=-L {}", dst.display());
-    println!("cargo:rerun-if-changed={}", src.to_str().unwrap());
-}
 
 fn main() {
-    let src = PathBuf::from(&env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("libsamplerate");
-    let dst = PathBuf::from(&env::var_os("OUT_DIR").unwrap());
-    let _ = fs::create_dir(&dst);
-    match env::var("CARGO_CFG_TARGET_OS").as_ref().map(|x| &**x) {
-        Ok("windows") => build_libsamplerate_windows(&src, &dst),
-        _ => build_libsamplerate_unix(&src, &dst),
-    };
+    let libsr = cmake::build("libsamplerate");
+    println!("cargo:rustc-link-search=native={}", libsr.join("lib").display());
+    println!("cargo:rustc-link-lib=static=samplerate");
+
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
         .generate()


### PR DESCRIPTION
I tried using this crate on Windows under MSVC, and the existing build script was not equipped to deal with that configuration. I've changed the build script to use the [cmake crate](https://docs.rs/cmake/0.1.44/cmake/) which has much smarter defaults. This makes the build script simpler, and also it now works with MSVC!

I think everything else should work the same, too. I've built this branch on Debian, MacOS, and Windows (both GCC and MSVC) and it works fine.