### PR TITLE
DO-NOT-MERGE: Problem with homebrew's libsamplerate in combination with Xcode 12+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
     - if: startsWith(matrix.os, 'macos')
       run: |
+        sudo xcode-select --switch /Applications/Xcode_12.app
+    - if: startsWith(matrix.os, 'macos')
+      run: |
         brew install libsamplerate
     - uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,9 @@ jobs:
             os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
+    - if: startsWith(matrix.os, 'macos')
+      run: |
+        brew install libsamplerate
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal


### PR DESCRIPTION
WARNING: This is not supposed to be merged!

This is just to illustrate a potential problem, as shown in CI.

The `libsamplerate` package of course doesn't have to be installed with `brew`, but it might be, probably as a dependency of another used package.

Anyway, when installing `libsamplerate` with `brew`, everything works fine, see 9f3a3d2525a2d69e27251d6b95240f607cab6292.

But wait for it ...