### PR TITLE
build.rs: use build_target()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ all_asserts = "0.1.4"
 
 [build-dependencies]
 bindgen = "0.51"
-cmake = "0.1"
+# 0.1.45 adds cmake::Config::get_profile()
+cmake = "0.1.45"

--- a/build.rs
+++ b/build.rs
@@ -5,8 +5,17 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let libsr = cmake::build("libsamplerate");
-    println!("cargo:rustc-link-search=native={}", libsr.join("lib").display());
+    let libsr = cmake::Config::new("libsamplerate")
+        .build_target("samplerate")
+        .build();
+    let path = libsr.join("build");
+
+    println!("cargo:rustc-link-search=native={}", path.display());
+    // Debug/Release/... paths for MSVC:
+    println!("cargo:rustc-link-search=native={}", path.join("Debug").display());
+    println!("cargo:rustc-link-search=native={}", path.join("Release").display());
+    println!("cargo:rustc-link-search=native={}", path.join("RelWithDebInfo").display());
+    println!("cargo:rustc-link-search=native={}", path.join("MinSizeRel").display());
     println!("cargo:rustc-link-lib=static=samplerate");
 
     let bindings = bindgen::Builder::default()

--- a/build.rs
+++ b/build.rs
@@ -5,17 +5,15 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let libsr = cmake::Config::new("libsamplerate")
-        .build_target("samplerate")
-        .build();
-    let path = libsr.join("build");
-
+    let mut config = cmake::Config::new("libsamplerate");
+    config.build_target("samplerate");
+    let mut path = config.build();
+    if std::env::var("TARGET").unwrap().contains("msvc") {
+        path = path.join("build").join(config.get_profile());
+    } else {
+        path = path.join("build");
+    }
     println!("cargo:rustc-link-search=native={}", path.display());
-    // Debug/Release/... paths for MSVC:
-    println!("cargo:rustc-link-search=native={}", path.join("Debug").display());
-    println!("cargo:rustc-link-search=native={}", path.join("Release").display());
-    println!("cargo:rustc-link-search=native={}", path.join("RelWithDebInfo").display());
-    println!("cargo:rustc-link-search=native={}", path.join("MinSizeRel").display());
     println!("cargo:rustc-link-lib=static=samplerate");
 
     let bindings = bindgen::Builder::default()


### PR DESCRIPTION
Fixes #8.

I have learned about this `cmake-rs` feature in https://github.com/mgeier/libflac-sys/pull/5.

An even better solution will become available in the next `cmake-rs` release, see https://github.com/alexcrichton/cmake-rs/pull/105.