### PR TITLE
Smaller package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,21 @@ version = "0.1.8"
 readme = "README.md"
 categories = ["multimedia::audio"]
 
+exclude = [
+    ".*",
+    "libsamplerate/appveyor.yml",
+    "libsamplerate/autogen.sh",
+    "libsamplerate/configure.ac",
+    "libsamplerate/Make.bat",
+    "libsamplerate/Makefile.am",
+    "libsamplerate/libsamplerate.spec.in",
+    "libsamplerate/doc/",
+    "libsamplerate/Octave/",
+    "libsamplerate/examples/",
+    "libsamplerate/m4/",
+    "libsamplerate/tests/",
+]
+
 [dev-dependencies]
 all_asserts = "0.1.4"
 

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,11 @@ extern crate cmake;
 
 fn main() {
     let mut config = cmake::Config::new("libsamplerate");
-    config.build_target("samplerate");
+    config
+        .define("LIBSAMPLERATE_TESTS", "OFF")
+        .define("LIBSAMPLERATE_EXAMPLES", "OFF")
+        .define("LIBSAMPLERATE_INSTALL", "OFF")
+        .build_target("samplerate");
     let mut path = config.build();
     if std::env::var("TARGET").unwrap().contains("msvc") {
         path = path.join("build").join(config.get_profile());


### PR DESCRIPTION
After #9, I was hoping to be able to reduce the package size significantly.

Sadly, I could only remove a very small part of the files and only reduce the size by a little bit.

It turns out most of the size in `libsamplerate` comes from a single header file which defines a ton of coefficients.

I'm not sure if this change is worth merging, feel free to close it unmerged!