### PR TITLE
allow dynamic linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,12 @@ exclude = [
     "libsamplerate/tests/",
 ]
 
+[features]
+default = []
+static = ["cmake"]
+
 [dev-dependencies]
 all_asserts = "2.2.0"
 
 [build-dependencies]
-cmake = "0.1"
+cmake = { version = "0.1", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,4 @@
-extern crate cmake;
-
+#[cfg(feature = "static")]
 fn main() {
     let mut config = cmake::Config::new("libsamplerate");
     config
@@ -15,4 +14,9 @@ fn main() {
     }
     println!("cargo:rustc-link-search=native={}", path.display());
     println!("cargo:rustc-link-lib=static=samplerate");
+}
+
+#[cfg(not(feature = "static"))]
+fn main() {
+    println!("cargo:rustc-link-lib=samplerate");
 }


### PR DESCRIPTION
This change allows us to dynamically link to an existing `libsamplerate`

Solves #10 