### PR TITLE
Specify arch as a CMake config on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-target
+.DS_Store
 Cargo.lock
+target

--- a/build.rs
+++ b/build.rs
@@ -7,12 +7,25 @@ fn main() {
         .define("LIBSAMPLERATE_EXAMPLES", "OFF")
         .define("LIBSAMPLERATE_INSTALL", "OFF")
         .build_target("samplerate");
+
+    let target = std::env::var("TARGET").unwrap();
+    if target.contains("darwin") {
+        let cmake_osx_arch = if target.contains("aarch64") {
+            "arm64"
+        } else {
+            "x86_64"
+        };
+        config.define("CMAKE_OSX_ARCHITECTURES", cmake_osx_arch);
+    }
+
     let mut path = config.build();
-    if std::env::var("TARGET").unwrap().contains("msvc") {
+
+    if target.contains("msvc") {
         path = path.join("build").join(config.get_profile());
     } else {
         path = path.join("build");
     }
+
     println!("cargo:rustc-link-search=native={}", path.display());
     println!("cargo:rustc-link-lib=static=samplerate");
 }


### PR DESCRIPTION
This is to make it possible to cross-compile on macOS (e.g. compile
a x86_64 binary on an arm64 host).